### PR TITLE
Fix: Textual configuration does not work if heartBeat parameter is not explicitely defined (NullPointerException)

### DIFF
--- a/ESH-INF/thing/HeosSystem.xml
+++ b/ESH-INF/thing/HeosSystem.xml
@@ -51,6 +51,7 @@
                 <context>String</context>
                 <label>Heart Beat</label>
                 <description>The time in seconds for the HEOS heart beat (default = 360s)</description>
+                <default>360</default>
                 <required>false</required>
             </parameter>              
         </config-description>


### PR DESCRIPTION
...setting default to 360 as stated in description should fix it