### PR TITLE
Handle channel not found

### DIFF
--- a/src/main/java/org/openhab/binding/heos/handler/HeosBridgeHandler.java
+++ b/src/main/java/org/openhab/binding/heos/handler/HeosBridgeHandler.java
@@ -90,7 +90,9 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
         }
 
         Channel channel = this.thing.getChannel(channelUID.getId());
-
+        if (channel == null) {
+            logger.error("Channel {} not found", channelUID.toString());
+        }
         if (channel.getChannelTypeUID().toString().equals("heos:ch_player")) {
             if (command.toString().equals("ON")) {
                 selectedPlayer.put(channel.getProperties().get(PID), channelUID.getId());


### PR DESCRIPTION
This happens when the bridge looses one of the players, not sure how that happens. But I do get a Nullpointer on this line.