### PR TITLE
Fix multithreading issues in child handler creation and disposal (#9)

### DIFF
--- a/src/main/java/org/openhab/binding/heos/handler/HeosBridgeHandler.java
+++ b/src/main/java/org/openhab/binding/heos/handler/HeosBridgeHandler.java
@@ -219,7 +219,7 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
      */
 
     @Override
-    public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
+    public synchronized void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
         handlerList.put(childThing.getUID(), childHandler);
         thingOnlineState.put(childThing.getUID(), ThingStatus.ONLINE);
         this.addPlayerChannel(childThing);
@@ -235,7 +235,7 @@ public class HeosBridgeHandler extends BaseBridgeHandler implements HeosEventLis
      */
 
     @Override
-    public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+    public synchronized void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
 
         if (this.getThing().getStatus().equals(ThingStatus.OFFLINE)) { // Prevents to change channels if bridge is
                                                                        // offline.


### PR DESCRIPTION
This should fix issue #9. I don't have the time to analyze what exactly the reasons for issue #9  are, but setting child handler methods to synchronized should bypass all multithreading issues within these methods. There is no noticeable performance penalty.

Since adding this fix, issue #9 does not occur anymore on my setup.